### PR TITLE
Update license header

### DIFF
--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright © 2017, Saleforce.com, Inc
+    Copyright © 2018, Salesforce.com, Inc
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/MavenParent/pom.xml
+++ b/MavenParent/pom.xml
@@ -106,7 +106,7 @@
                         <header>com/mycila/maven/plugin/license/templates/${parameter.license}.txt</header>
                         <encoding>utf8</encoding>
                         <properties>
-                            <owner>Saleforce.com, Inc</owner>
+                            <owner>Salesforce.com, Inc</owner>
                             <email>rex.hoffman@salesforce.com</email>
                         </properties>
                         <excludes>

--- a/MavenSiteSkin/src/test/java/Base64EncodeTest.java
+++ b/MavenSiteSkin/src/test/java/Base64EncodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017, Saleforce.com, Inc
+ * Copyright © 2018, Salesforce.com, Inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
saleforce.com redirects to salesforce.com, but still this is a typo.