### PR TITLE
update the circelci yaml schema version and jdk image to work with ci…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,23 @@
-version: 2.0
+version: 2.1
 
 jobs:
   build:
     docker:
-      - image: docker.io/azul/zulu-openjdk-centos:8
+      # see https://circleci.com/developer/images/image/cimg/openjdk
+      - image: cimg/openjdk:8.0.442
     steps:
-      - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "pom.xml" }} # appends cache key with a hash of pom.xml file
+            - v1-dependencies-{{ checksum "${CIRCLE_PROJECT_REPONAME}/pom.xml" }} # appends cache key with a hash of pom.xml file
             - v1-dependencies- # fallback in case previous cache key is not found
-      - run: ./.mvn/mvnw clean install --settings .circleci/settings.xml -Dmaven.javadoc.skip=true -Dgpg.skip=true
+      - run: |
+          git clone "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+          pushd "${CIRCLE_PROJECT_REPONAME}"
+          git fetch origin || git remote -v
+          git checkout -f "${CIRCLE_SHA1}"
+          git clean -dffx
+          ./.mvn/mvnw clean install --settings .circleci/settings.xml -Dmaven.javadoc.skip=true -Dgpg.skip=true
       - save_cache:
             paths:
               - ~/.m2
-            key: v1-dependencies-{{ checksum "pom.xml" }}
+            key: v1-dependencies-{{ checksum "${CIRCLE_PROJECT_REPONAME}/pom.xml" }}


### PR DESCRIPTION
I scoured their docs and was not able to find a premade git clone step over https, the checkout step requires ssh, and I don't want to configure a long-lived public key in the project.