### PR TITLE
Partial downgrade of maven-site-plugin from f30a118 to support report…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <version.nexus.staging.maven.plugin>1.6.8</version.nexus.staging.maven.plugin>
         <version.pmd.maven.plugin>3.26.0</version.pmd.maven.plugin>
         <version.reports.maven.plugin>3.1.2</version.reports.maven.plugin>
-        <version.site.maven.plugin>3.21.0</version.site.maven.plugin>
+        <version.site.maven.plugin>3.12.1</version.site.maven.plugin>
         <version.sortpom.maven.plugin>2.12.0</version.sortpom.maven.plugin>
         <version.sources.maven.plugin>3.2.1</version.sources.maven.plugin>
     </properties>


### PR DESCRIPTION
Noticed that the site skin's headers render incorrectly with i18n getters exposed, and a few other reporting plugins have similar template exposure and don't render correctly.

The site-maven-pugin has this detailed compatibility matrix which I used to select the latest version of the plugin possible for the reporting plugin doxia usage: https://maven.apache.org/plugins/maven-site-plugin/history.html