### PR TITLE
Upgrade checkstyle to the latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     docker:
       # see https://circleci.com/developer/images/image/cimg/openjdk
-      - image: cimg/openjdk:8.0.442
+      - image: cimg/openjdk:11.0.29
     steps:
       - run: |
           git clone "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"

--- a/MavenAnalysisConf/src/main/resources/checkstyle.xml
+++ b/MavenAnalysisConf/src/main/resources/checkstyle.xml
@@ -248,7 +248,7 @@
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <!-- javadoc may warn or fail on missing tags -->
             <property name="allowMissingParamTags" value="false"/>
             <property name="validateThrows" value="true"/>

--- a/MavenParent/pom.xml
+++ b/MavenParent/pom.xml
@@ -29,7 +29,7 @@
         <parameter.checkstyle.xml>checkstyle.xml</parameter.checkstyle.xml>
         <parameter.disable.semantic.versioning>false</parameter.disable.semantic.versioning>
         <!-- execution of maven must occur within java version below or greater -->
-        <parameter.enforcer.min.java.version>1.8.0</parameter.enforcer.min.java.version>
+        <parameter.enforcer.min.java.version>11</parameter.enforcer.min.java.version>
         <parameter.enforcer.min.maven.version>3.5.0</parameter.enforcer.min.maven.version>
         <!-- example for following parameter: org.apache.maven.plugins:maven-enforcer-plugin,org.apache.maven.plugins:maven-idea-plugin -->
         <parameter.enforcer.unchecked.plugins.list></parameter.enforcer.unchecked.plugins.list>
@@ -50,7 +50,7 @@
         <parameter.takari.proc>proc</parameter.takari.proc>
         <parameter.takari.transitiveDependencyReference>error</parameter.takari.transitiveDependencyReference>
         <!-- max version of checkstyle supported by m2e  8.14 -->
-        <version.checkstyle>8.29</version.checkstyle>
+        <version.checkstyle>10.26.1</version.checkstyle>
         <version.checkstyle.maven.plugin>3.6.0</version.checkstyle.maven.plugin>
         <version.depedency.maven.plugin>3.8.1</version.depedency.maven.plugin>
         <version.deployer.maven.plugin>3.1.4</version.deployer.maven.plugin>


### PR DESCRIPTION
checkstyle was complaining that my `record` class wasn't a real token in the language because it's too old to know it now is :). Minor config update to handle an api-incompatibility where they renamed 'scope' to 'accessModifiers'.

Update: this version of checkstyle requires jdk 11+, so this is a bigger change than I wanted. 🤔 